### PR TITLE
Updated the npm start command with a fix for the issue found by Bruce

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "when": "^3.7.3"
   },
   "scripts": {
-    "start": "npm link || TRUE && charge ./public --p ${PORT} 8080"
+    "start": "npm link || true && charge ./public --p ${PORT} 8080"
   },
   "devDependencies": {
     "jeet": "^6.1.2",


### PR DESCRIPTION
Updates the npm start command to use a lowercase TRUE which succeeds in OSX but fails on a Linux machine.
